### PR TITLE
Allow User to Choose Alt Magento Tarball

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A VERY simple Magento environment provisioner for [Vagrant](http://www.vagrantup
 
 * Creates a running Magento development environment with a few simple commands.
 * Runs on Ubuntu (Precise 12.04 64 Bit) \w PHP 5.3, MySQL 5.5, Apache 2.2
-* Uses [Magento CE 1.9.0.1](http://www.magentocommerce.com/download)
+* Uses [Magento CE 1.9.0.1](http://www.magentocommerce.com/download) or [provide your own](#provide-your-own-magento)
 * Automatically runs Magento's installer and creates CMS admin account.
 * Automatically runs [n98-magerun](https://github.com/netz98/n98-magerun) installer. 
 * Perfect for rapid development or extension testing with an unopionionated, bare-bones and easily tweaked configuration.
@@ -33,6 +33,10 @@ Vagrant will configure the base system before downloading Magento and running th
 * User: `admin` Password: `password123123`
 * Access the virtual machine directly using `vagrant ssh`
 * When you're done `vagrant halt`
+
+### Provide Your Own Magento
+
+If you put a file in the vagrant shared directory named 'magento.tar', the provisioner will use it instead of downloading Magento CE 1.9.0.1. For example, if you have an Enterprise Edition or other Magento you want to use, drop it in the directory before building and symlink it to magento.tar.
 
 [Full Vagrant command documentation](http://docs.vagrantup.com/v2/cli/index.html)
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,16 +50,25 @@ mysql -u root -e "FLUSH PRIVILEGES"
 # --------------------
 # http://www.magentocommerce.com/wiki/1_-_installation_and_configuration/installing_magento_via_shell_ssh
 
-# Download and extract
+## Download and extract
+
+# If there's a magento.tar in vagrant, use that.
+# Hint: Put a bunch of magentos in here and symlink the one you want
+#       to magento.tar. tar can figure out which decompressor to use.
+magefile=/vagrant/magento.tar
+
+# If there's no magento.tar in vagrant, fetch one and symlink it.
+if [ ! -f "$magefile" ] && cd /vagrant; then
+  mageurl='http://www.magentocommerce.com/downloads/assets/1.9.0.1/magento-1.9.0.1.tar.gz'
+	wget "$mageurl"
+	ln -s "${mageurl##*/}" magento.tar
+fi
+
 if [ ! -f "/vagrant/httpdocs/index.php" ]; then
   cd /vagrant/httpdocs
-  wget http://www.magentocommerce.com/downloads/assets/1.9.0.1/magento-1.9.0.1.tar.gz
-  tar -zxvf magento-1.9.0.1.tar.gz
-  mv magento/* magento/.htaccess .
+  tar --strip-components=1 -xf "$magefile"
   chmod -R o+w media var
   chmod o+w app/etc
-  # Clean up downloaded file and extracted dir
-  rm -rf magento*
 fi
 
 # Run installer


### PR DESCRIPTION
If a user puts a magento.tar in the Vagrantfile directory it will be used instead of fetching one. This allows people to use another version or adapted Magento from the get-go. It is fully compatible with the original behavior – if no magento.tar is provided, the provisioner will fetch one.
